### PR TITLE
Tier and hotspot annotation added to P1 table

### DIFF
--- a/code/tier_classification/README.md
+++ b/code/tier_classification/README.md
@@ -1,0 +1,58 @@
+## Tier and Hotspot Annotation for Samples Used in OMPARE
+
+This module contains R script that added `Tier: xx` and `Cancer Hotspot` to the tables in P1:
+`key_clinical_findings_output` and `all_findings_output`.
+
+### Usage
+The module does not have a run-script.sh but each script can be run individually as followed:
+  
+```
+Rscript tier_classification.R
+```
+
+Input file `oncokb_consensus_annotated.txt`
+
+1. Tier 1 variants: 
+  a. Levels of evidence to include among Tier 1 would be: in the `HIGHEST_LEVEL` field, those with levels 1-3; OR in the `Highest DX Level`, levels 1-2; OR in the `Highest PX Level`, levels 1-2. 
+  b. Mutation type: from MAF `Variant_Classification` field - missense, nonsense, indel (frameshift/non-frameshift), splice site, splice region.
+  c. Variant allele frequency > 0.05: Calculated as `VAF = t_alt_count/(t_alt_count+t_ref_count)`
+  d. Population database: from MAF - `gnomad_AF` < 0.01
+  e. From MAF: `Existing_variation`: Must contain `COSM` identifier (found in COSMIC). 
+  g. Pathways: Known TSG or Oncogene given OMPARE knowledgebase (`cancer_gene_list.rds`). 
+  h. Publications: from `oncokb_consensus_annotated.txt`, `CITATIONS` is non-empty
+
+2. Tier 2 variants: 
+  a. Levels of evidence to include among Tier 2 would be: - in the `HIGHEST_LEVEL` field, those variants only with level 4 evidence; OR in the `Highest DX Level`, level 3; OR in the `Highest PX Level`, level 3. (Note: a given variant may have multiple Levels of evidence in different indications, so long as the levels don't exceed 3 for DX or PX, nor 4 for `Level`, it would remain a Tier2 variant. If a variant has a level higher in any single one of these categories, it is a Tier 1 variant). 
+  b. Mutation type: from MAF `Variant_Classification` field - missense, nonsense, indel (frameshift/non-frameshift), splice site, splice region.
+  c. Variant allele frequency > 0.05: Calculated as `VAF = t_alt_count/(t_alt_count+t_ref_count)`
+  d. Population database: from MAF - `gnomad_AF` < 0.01
+  e. From MAF: `Existing_variation`: Must contain `COSM` identifier (found in COSMIC). 
+  g. Pathways: Known TSG or Oncogene 
+  h. Publications: from `oncokb_consensus_annotated.txt`, `CITATIONS` is non-empty
+
+3. Tier 3 variants (VUS): 
+  a. No levels annotation in `oncokb_consensus_annotated.txt`
+  b. Mutation type: from MAF `Variant_Classification` field - missense, in-frame insertions and deletions
+  c. Variant allele frequency > 0.05: Calculated as `VAF = t_alt_count/(t_alt_count+t_ref_count)`
+  d. Population database: from MAF - `gnomad_AF` < 0.01
+  e. From MAF: `Existing_variation`: May or may not contain `COSM` identifier (found in COSMIC). 
+  g. Pathways: Gene may or may not map be included in TSG or oncogene list
+  h. Publications: from `oncokb_consensus_annotated.txt`, `CITATIONS` may or may not be empty
+
+4. Tier 4 variants (Benign): 
+  a. No levels annotation in `oncokb_consensus_annotated.txt`
+  b. Mutation type: from MAF `Variant_Classification` field - missense
+  c. Variant allele frequency either 40%-60% or >90% (non-mosaic): Calculated as `VAF = t_alt_count/(t_alt_count+t_ref_count)`
+  d. Population database: from MAF - `gnomad_AF` >= 0.01
+  e. From MAF:  `SIFT` and `Polyphen` do not contain `deleterious` or `damaging`, respectively
+  f. Pathways: Gene is not a known TSG or oncogene
+  g. Publications: from `oncokb_consensus_annotated.txt`, `CITATIONS` is empty
+  
+For annotating cancer hotspot, `hotspot_database_2017_indel.tsv` and `hotspot_database_2017_snv.tsv` were used.
+
+To see whether SNV hotspot were present, the `key_clinical_findings_output` and `all_findings_output` were first filtered to contain only `Missense_Mutation`, `Nonsense_Mutation`, `Splic_Variant` and `Splice_Region`. 
+For every entry in the hotspot file, the gene symbol and AA position were used to query the `key_clinical_findings_output` and `all_findings_output` table to see whether they are present - if yes, then `Cancer Hotspot` annotation will be added to the `Variant_Properties` column.
+
+To see whether indel hotspot were present, the `key_clinical_findings_output` and `all_findings_output` were first filtered to contain only `Frame_Shift_Del`, `Frame_Shift_Ins`m `In_Frame_Del` and `In_Frame_Ins`. 
+For every entry in the indel hotspot file, the gene symbol and AA start and end position were used to query the `key_clinical_findings_output` and `all_findings_output` table to see whether they are present - if yes, then `Cancer Hotspot` annotation will be added to the `Variant_Properties` column.
+

--- a/code/tier_classification/README.md
+++ b/code/tier_classification/README.md
@@ -48,7 +48,7 @@ Input file `oncokb_consensus_annotated.txt`
   f. Pathways: Gene is not a known TSG or oncogene
   g. Publications: from `oncokb_consensus_annotated.txt`, `CITATIONS` is empty
   
-For annotating cancer hotspot, `hotspot_database_2017_indel.tsv` and `hotspot_database_2017_snv.tsv` were used.
+`hotspot_database_2017_indel.tsv` and `hotspot_database_2017_snv.tsv` derived from curated MSKCC data in OpenPBTA (https://github.com/AlexsLemonade/OpenPBTA-analysis/tree/master/analyses/hotspots-detection) were used for annotating cancer hotspot mutations.
 
 To see whether SNV hotspot were present, the `key_clinical_findings_output` and `all_findings_output` were first filtered to contain only `Missense_Mutation`, `Nonsense_Mutation`, `Splic_Variant` and `Splice_Region`. 
 For every entry in the hotspot file, the gene symbol and AA position were used to query the `key_clinical_findings_output` and `all_findings_output` table to see whether they are present - if yes, then `Cancer Hotspot` annotation will be added to the `Variant_Properties` column.

--- a/code/tier_classification/tier_classification.R
+++ b/code/tier_classification/tier_classification.R
@@ -96,7 +96,7 @@ oncokb_anno_tier3 <- oncokb_anno %>%
   # filter to variation of interest 
   dplyr::filter(Variant_Classification %in% c('Missense_Mutation',  # filter the files 
                                               'In_Frame_Del', 'In_Frame_Ins')) %>%
-  # filter to samples that do not have OncoKB annotation
+  # filter to samples that do not have OncoKB annotation 
   dplyr::filter(is.na(HIGHEST_LEVEL)) %>%
   dplyr::filter(is.na(HIGHEST_DX_LEVEL)) %>%
   dplyr::filter(is.na(HIGHEST_PX_LEVEL)) %>%
@@ -110,14 +110,17 @@ oncokb_anno_tier3 <- oncokb_anno %>%
 oncokb_anno_tier4 <- oncokb_anno %>% 
   # filter to variation of interest 
   dplyr::filter(Variant_Classification =='Missense_Mutation') %>%
-  # filter to samples that do not have OncoKB annotation
+  # filter to samples that do not have OncoKB annotation or related citations
   dplyr::filter(is.na(HIGHEST_LEVEL)) %>%
   dplyr::filter(is.na(HIGHEST_DX_LEVEL)) %>%
   dplyr::filter(is.na(HIGHEST_PX_LEVEL)) %>%
+  dplyr::filter(is.na(CITATIONS)) %>% 
   # contain only variants that are <1% (less likely to be germline)
   dplyr::filter(gnomAD_AF>=0.01) %>%
   # filter on VAF over 5% to avoid background noise
   dplyr::filter((VAF>=0.4 & VAF<=0.6) | VAF>=0.9) %>%
+  dplyr::filter(!grepl("deleterious", SIFT)) %>%
+  dplyr::filter(!grepl("damaging", PolyPhen)) %>%
   dplyr::mutate(tier_classification = "TIER: IV")
 
 # combine all the variants in MAF that contain Tier information 

--- a/code/tier_classification/tier_classification.R
+++ b/code/tier_classification/tier_classification.R
@@ -1,0 +1,146 @@
+# Author: Run Jin
+# Classify SNV mutation results into 4 tier [@doi:10.1016/j.jmoldx.2016.10.002]
+
+suppressPackageStartupMessages({
+  library(optparse)
+  library(tidyverse)
+  library(readr)
+})
+
+# function to get all directories
+
+# Define Directories
+root_dir <- rprojroot::find_root(rprojroot::has_dir(".git"))
+data_dir <- file.path(root_dir, "data")
+input_dir <- file.path(patient_dir, "output", "oncokb_analysis")
+
+# Read in files necessary for analyses
+oncokb_anno <- readr::read_tsv(file.path(input_dir, "oncokb_consensus_annotated.txt"))
+cancer_genes <- readRDS(file.path(data_dir, 'cancer_gene_list.rds'))
+
+# find the oncogenes tumor suppressor genes in OMPARE knowledge base
+oncogenes_tsg <- cancer_genes %>%
+  filter(type %in% c("Is.Oncogene", "Oncogene", "Is.Tumor.Suppressor.Gene", "TumorSuppressorGene")) %>%
+  .$Gene_Symbol %>% unique
+
+# calculate VAF for subsequent classification 
+oncokb_anno <- oncokb_anno %>% 
+  dplyr::mutate(VAF = t_alt_count/(t_alt_count+t_ref_count))
+
+# Filter for Tier I
+oncokb_anno_tier1 <- oncokb_anno %>% 
+  # filter to variation of interest 
+  dplyr::filter(Variant_Classification %in% c('Missense_Mutation', 'Nonsense_Mutation', # filter the files 
+                              'Frame_Shift_Del', 'Frame_Shift_Ins', 
+                              'In_Frame_Del', 'In_Frame_Ins', 
+                              'Splice_Region', 'Splice_Site')) %>%
+  # filter based on OncoKB annotation level 
+  dplyr::filter(HIGHEST_LEVEL %in% c("LEVEL_1","LEVEL_2","LEVEL_3A", "LEVEL_3B", "LEVEL_R1") | HIGHEST_DX_LEVEL %in% c("LEVEL_Dx1","LEVEL_Dx2") | HIGHEST_PX_LEVEL %in% c("LEVEL_Px1","LEVEL_Px2")) %>%
+  # contain only variants that are <1% (less likely to be germline)
+  dplyr::filter(gnomAD_AF<0.01| is.na(gnomAD_AF)) %>%
+  # filter on VAF over 5% to avoid background noise
+  dplyr::filter(VAF>0.05) %>%
+  # filter to contain only mutations that has COSMIC ID
+  dplyr::mutate(has_COSMIC = dplyr::case_when(
+    stringr::str_detect(Existing_variation,
+                        "COSM") ~ "Yes",
+    TRUE ~ "No"
+  )) %>%
+  dplyr::filter(has_COSMIC == "Yes") %>%
+  # filter to contain only mutations with citations
+  dplyr::filter(!is.na(CITATIONS)) %>% 
+  # filter to TSG lists in OMPARE database
+  dplyr::filter(Hugo_Symbol %in% oncogenes_tsg ) %>% 
+  dplyr::select(-has_COSMIC) %>% 
+  dplyr::mutate(tier_classification = "TIER I")
+  
+
+# Filter for Tier II
+oncokb_anno_tier2 <- oncokb_anno %>% 
+  # filter to variation of interest 
+  dplyr::filter(Variant_Classification %in% c('Missense_Mutation', 'Nonsense_Mutation', # filter the files 
+                                              'Frame_Shift_Del', 'Frame_Shift_Ins', 
+                                              'In_Frame_Del', 'In_Frame_Ins', 
+                                              'Splice_Region', 'Splice_Site')) %>%
+  # filter based on OncoKB annotation level 
+  dplyr::filter(HIGHEST_LEVEL %in% c("LEVEL_4","LEVEL_R2") | HIGHEST_DX_LEVEL %in% c("LEVEL_Dx3") | HIGHEST_PX_LEVEL %in% c("LEVEL_Px3")) %>%
+  # contain only variants that are <1% (less likely to be germline)
+  dplyr::filter(gnomAD_AF<0.01| is.na(gnomAD_AF)) %>%
+  # filter on VAF over 5% to avoid background noise
+  dplyr::filter(VAF>0.05) %>%
+  # filter to contain only mutations that has COSMIC ID
+  dplyr::mutate(has_COSMIC = dplyr::case_when(
+    stringr::str_detect(Existing_variation,
+                        "COSM") ~ "Yes",
+    TRUE ~ "No"
+  )) %>%
+  dplyr::filter(has_COSMIC == "Yes") %>%
+  # filter to contain only mutations with citations
+  dplyr::filter(!is.na(CITATIONS)) %>% 
+  # filter to TSG lists in OMPARE database
+  dplyr::filter(Hugo_Symbol %in% oncogenes_tsg ) %>% 
+  dplyr::select(-has_COSMIC) %>% 
+  dplyr::mutate(tier_classification = "TIER II")
+
+
+# Filter for Tier III
+oncokb_anno_tier3 <- oncokb_anno %>% 
+  # filter to variation of interest 
+  dplyr::filter(Variant_Classification %in% c('Missense_Mutation',  # filter the files 
+                                              'In_Frame_Del', 'In_Frame_Ins')) %>%
+  # filter to samples that do not have OncoKB annotation
+  dplyr::filter(is.na(HIGHEST_LEVEL)) %>%
+  dplyr::filter(is.na(HIGHEST_DX_LEVEL)) %>%
+  dplyr::filter(is.na(HIGHEST_PX_LEVEL)) %>%
+  # contain only variants that are <1% (less likely to be germline)
+  dplyr::filter(gnomAD_AF<0.01| is.na(gnomAD_AF)) %>%
+  # filter on VAF over 5% to avoid background noise
+  dplyr::filter(VAF>0.05) %>%
+  dplyr::mutate(tier_classification = "TIER III")
+
+# Filter for Tier IV
+oncokb_anno_tier4 <- oncokb_anno %>% 
+  # filter to variation of interest 
+  dplyr::filter(Variant_Classification =='Missense_Mutation') %>%
+  # filter to samples that do not have OncoKB annotation
+  dplyr::filter(is.na(HIGHEST_LEVEL)) %>%
+  dplyr::filter(is.na(HIGHEST_DX_LEVEL)) %>%
+  dplyr::filter(is.na(HIGHEST_PX_LEVEL)) %>%
+  # contain only variants that are <1% (less likely to be germline)
+  dplyr::filter(gnomAD_AF>=0.01) %>%
+  # filter on VAF over 5% to avoid background noise
+  dplyr::filter((VAF>=0.4 & VAF<=0.6) | VAF>=0.9) %>%
+  dplyr::mutate(tier_classification = "TIER IV")
+
+# combine all the variants in MAF that contain Tier information 
+oncokb_anno_tiers <- bind_rows(oncokb_anno_tier1, oncokb_anno_tier2, oncokb_anno_tier3, oncokb_anno_tier4) %>%
+  dplyr::select(Hugo_Symbol, Variant_Classification, HGVSp_Short, tier_classification)
+
+# annotate TIER information to Key clinical findings output 
+
+key_clinical_findings_output_modified <- data.frame()
+
+for(i in 1:nrow(oncokb_anno_tiers)) {
+  # for each mutation, find the matching entries in the key clinical findings table (if present)
+  each <- oncokb_anno_tiers[i,]
+  gene_symbol <- each$Hugo_Symbol
+  variant_classification <- each$Variant_Classification
+  hgvs_short <- each$HGVSp_Short
+  tier_class <- each$tier_classification
+  
+  # make changes to variant property column when TIER information is available
+  key_clinical_findings_output_added <- key_clinical_findings_output %>% 
+    dplyr::filter(grepl(variant_classification, Details) & grepl(hgvs_short, Details)) %>%
+    dplyr::mutate(Variant_Properties = paste0(tier_class, "; ", Variant_Properties))
+  
+  # save the edited entries
+  key_clinical_findings_output_modified <- key_clinical_findings_output_modified %>% rbind(key_clinical_findings_output_added)
+}
+
+# merge the modified rows back to the original table 
+key_clinical_findings_output_unchanged <- key_clinical_findings_output %>% 
+  dplyr::filter(!Details %in% key_clinical_findings_output_modified$Details)
+
+key_clinical_findings_output <- bind_rows(key_clinical_findings_output_modified, key_clinical_findings_output_unchanged)
+
+

--- a/code/tier_classification/tier_classification.R
+++ b/code/tier_classification/tier_classification.R
@@ -143,7 +143,7 @@ for(p in 1:nrow(hotspot_snv)){
   all_findings_output_hotspot <- all_findings_output %>%
     dplyr::filter(Aberration == hotspot_gene & grepl(hotspot_aa_position, Details)) %>%
     dplyr::filter(grepl("Missense_Mutation", Details) | grepl("Nonsense_Mutation", Details) | grepl("Splice_Site", Details) | grepl("Splice_Region", Details))%>%
-    dplyr::mutate(Variant_Properties= paste0("Cancer Hotspot; ", Variant_Properties))
+    dplyr::mutate(Variant_Properties= paste0("Cancer Hotspot Location; ", Variant_Properties))
   
   all_findings_output_hotspots <- bind_rows(all_findings_output_hotspots, all_findings_output_hotspot)
   

--- a/code/tier_classification/tier_classification.R
+++ b/code/tier_classification/tier_classification.R
@@ -150,7 +150,7 @@ for(p in 1:nrow(hotspot_snv)){
   key_clinical_findings_output_hotspot <- key_clinical_findings_output %>% 
     dplyr::filter(Aberration == hotspot_gene & grepl(hotspot_aa_position, Details)) %>%
     dplyr::filter(grepl("Missense_Mutation", Details) | grepl("Nonsense_Mutation", Details) | grepl("Splice_Site", Details) | grepl("Splice_Region", Details))%>%
-    dplyr::mutate(Variant_Properties= paste0("Cancer Hotspot; ", Variant_Properties))
+    dplyr::mutate(Variant_Properties= paste0("Cancer Hotspot Location; ", Variant_Properties))
   
   key_clinical_findings_output_hotspots <- bind_rows(key_clinical_findings_output_hotspots, key_clinical_findings_output_hotspot)
 }

--- a/code/tier_classification/tier_classification.R
+++ b/code/tier_classification/tier_classification.R
@@ -16,7 +16,15 @@ input_dir <- file.path(patient_dir, "output", "oncokb_analysis")
 
 # Read in files necessary for analyses
 oncokb_anno <- readr::read_tsv(file.path(input_dir, "oncokb_consensus_annotated.txt"))
+
+# Read in cancer genes list from OMPARE knowledge base
 cancer_genes <- readRDS(file.path(data_dir, 'cancer_gene_list.rds'))
+
+# Read in hotspot database
+hotspot_indel <- readr::read_tsv(file.path(data_dir, 'hotspots_database', 'hotspot_database_2017_indel.tsv')) %>% 
+  distinct()
+hotspot_snv <- readr::read_tsv(file.path(data_dir, 'hotspots_database', 'hotspot_database_2017_snv.tsv')) %>%
+  distinct()
 
 # find the oncogenes tumor suppressor genes in OMPARE knowledge base
 oncogenes_tsg <- cancer_genes %>%
@@ -52,7 +60,7 @@ oncokb_anno_tier1 <- oncokb_anno %>%
   # filter to TSG lists in OMPARE database
   dplyr::filter(Hugo_Symbol %in% oncogenes_tsg ) %>% 
   dplyr::select(-has_COSMIC) %>% 
-  dplyr::mutate(tier_classification = "TIER I")
+  dplyr::mutate(tier_classification = "TIER: I")
   
 
 # Filter for Tier II
@@ -80,7 +88,7 @@ oncokb_anno_tier2 <- oncokb_anno %>%
   # filter to TSG lists in OMPARE database
   dplyr::filter(Hugo_Symbol %in% oncogenes_tsg ) %>% 
   dplyr::select(-has_COSMIC) %>% 
-  dplyr::mutate(tier_classification = "TIER II")
+  dplyr::mutate(tier_classification = "TIER: II")
 
 
 # Filter for Tier III
@@ -96,7 +104,7 @@ oncokb_anno_tier3 <- oncokb_anno %>%
   dplyr::filter(gnomAD_AF<0.01| is.na(gnomAD_AF)) %>%
   # filter on VAF over 5% to avoid background noise
   dplyr::filter(VAF>0.05) %>%
-  dplyr::mutate(tier_classification = "TIER III")
+  dplyr::mutate(tier_classification = "TIER: III")
 
 # Filter for Tier IV
 oncokb_anno_tier4 <- oncokb_anno %>% 
@@ -110,15 +118,91 @@ oncokb_anno_tier4 <- oncokb_anno %>%
   dplyr::filter(gnomAD_AF>=0.01) %>%
   # filter on VAF over 5% to avoid background noise
   dplyr::filter((VAF>=0.4 & VAF<=0.6) | VAF>=0.9) %>%
-  dplyr::mutate(tier_classification = "TIER IV")
+  dplyr::mutate(tier_classification = "TIER: IV")
 
 # combine all the variants in MAF that contain Tier information 
 oncokb_anno_tiers <- bind_rows(oncokb_anno_tier1, oncokb_anno_tier2, oncokb_anno_tier3, oncokb_anno_tier4) %>%
   dplyr::select(Hugo_Symbol, Variant_Classification, HGVSp_Short, tier_classification)
 
-# annotate TIER information to Key clinical findings output 
 
-key_clinical_findings_output_modified <- data.frame()
+######################### annotate MSK SNV hotspot database to key clinical findings & all findings table
+
+# annotate SNV first
+all_findings_output_hotspots <- data.frame()
+key_clinical_findings_output_hotspots <- data.frame()
+
+for(p in 1:nrow(hotspot_snv)){
+  
+  each_entry <- hotspot_snv[p,]
+  hotspot_gene <- each_entry$Hugo_Symbol
+  hotspot_aa_position <- each_entry$Amino_Acid_Position
+  
+  all_findings_output_hotspot <- all_findings_output %>%
+    dplyr::filter(Aberration == hotspot_gene & grepl(hotspot_aa_position, Details)) %>%
+    dplyr::filter(grepl("Missense_Mutation", Details) | grepl("Nonsense_Mutation", Details) | grepl("Splice_Site", Details) | grepl("Splice_Region", Details))%>%
+    dplyr::mutate(Variant_Properties= paste0("Cancer Hotspot; ", Variant_Properties))
+  
+  all_findings_output_hotspots <- bind_rows(all_findings_output_hotspots, all_findings_output_hotspot)
+  
+  key_clinical_findings_output_hotspot <- key_clinical_findings_output %>% 
+    dplyr::filter(Aberration == hotspot_gene & grepl(hotspot_aa_position, Details)) %>%
+    dplyr::filter(grepl("Missense_Mutation", Details) | grepl("Nonsense_Mutation", Details) | grepl("Splice_Site", Details) | grepl("Splice_Region", Details))%>%
+    dplyr::mutate(Variant_Properties= paste0("Cancer Hotspot; ", Variant_Properties))
+  
+  key_clinical_findings_output_hotspots <- bind_rows(key_clinical_findings_output_hotspots, key_clinical_findings_output_hotspot)
+}
+
+# add the annotations to the file 
+key_clinical_findings_output_not_hotspot <- key_clinical_findings_output %>% 
+  dplyr::filter(!Details %in% key_clinical_findings_output_hotspots$Details)
+key_clinical_findings_output <- bind_rows(key_clinical_findings_output_not_hotspot, key_clinical_findings_output_hotspots)
+
+# add the annotations to the file 
+all_findings_output_not_hotspot <- all_findings_output %>% 
+  dplyr::filter(!Details %in% all_findings_output_hotspots$Details)
+all_findings_output <- bind_rows(all_findings_output_not_hotspot, all_findings_output_hotspots)
+
+######################### annotate MSK Indel hotspot database to key clinical findings & all findings table
+
+# annotate Indel now
+all_findings_output_indels <- data.frame()
+key_clinical_findings_output_indels <- data.frame()
+
+for(q in 1:nrow(hotspot_indel)){
+  
+  each_indel <- hotspot_indel[q,]
+  hotspot_gene_indel <- each_indel$Hugo_Symbol
+  hotspot_aa_start <- each_indel$Amino_Acid_Start
+  hotspot_aa_end <- each_indel$Amino_Acid_End
+
+  all_findings_output_indel <- all_findings_output %>%
+    dplyr::filter(Aberration == hotspot_gene_indel & grepl(hotspot_aa_start, Details) & grepl(hotspot_aa_end, Details)) %>%
+    dplyr::filter(grepl("Frame_Shift_Del", Details) | grepl("Frame_Shift_Ins", Details) | grepl("In_Frame_Del", Details) | grepl("In_Frame_Ins", Details))%>%
+    mutate(Variant_Properties= paste0("Cancer Hotspot; ", Variant_Properties))
+  all_findings_output_indels <- bind_rows(all_findings_output_indel, all_findings_output_indels)
+  
+  key_clinical_findings_output_indel <- key_clinical_findings_output %>%
+    dplyr::filter(Aberration == hotspot_gene_indel & grepl(hotspot_aa_start, Details) & grepl(hotspot_aa_end, Details)) %>%
+    dplyr::filter(grepl("Frame_Shift_Del", Details) | grepl("Frame_Shift_Ins", Details) | grepl("In_Frame_Del", Details) | grepl("In_Frame_Ins", Details))%>%
+    mutate(Variant_Properties= paste0("Cancer Hotspot; ", Variant_Properties))
+  key_clinical_findings_output_indels <- bind_rows(key_clinical_findings_output_indel, key_clinical_findings_output_indels)
+}
+
+# add the annotations to the file 
+key_clinical_findings_output_no_indels <- key_clinical_findings_output %>% 
+  dplyr::filter(!Details %in% key_clinical_findings_output_indels$Details)
+key_clinical_findings_output <- bind_rows(key_clinical_findings_output_indels, key_clinical_findings_output_no_indels)
+
+# add the annotations to the file 
+all_findings_output_no_indels <- all_findings_output %>% 
+  dplyr::filter(!Details %in% all_findings_output_indels$Details)
+all_findings_output <- bind_rows(all_findings_output_no_indels, all_findings_output_indels)
+
+
+######################### annotate TIER information to Key clinical findings output and all findings output
+
+key_clinical_findings_output_tiers <- data.frame()
+all_findings_output_tiers <- data.frame()
 
 for(i in 1:nrow(oncokb_anno_tiers)) {
   # for each mutation, find the matching entries in the key clinical findings table (if present)
@@ -129,18 +213,32 @@ for(i in 1:nrow(oncokb_anno_tiers)) {
   tier_class <- each$tier_classification
   
   # make changes to variant property column when TIER information is available
-  key_clinical_findings_output_added <- key_clinical_findings_output %>% 
-    dplyr::filter(grepl(variant_classification, Details) & grepl(hgvs_short, Details)) %>%
-    dplyr::mutate(Variant_Properties = paste0(tier_class, "; ", Variant_Properties))
+  key_clinical_findings_output_tier <- key_clinical_findings_output %>% 
+    dplyr::filter(Aberration == gene_symbol & grepl(variant_classification, Details) & grepl(hgvs_short, Details)) %>%
+    dplyr::mutate(Variant_Properties =paste0(tier_class, "; ", Variant_Properties))
   
-  # save the edited entries
-  key_clinical_findings_output_modified <- key_clinical_findings_output_modified %>% rbind(key_clinical_findings_output_added)
+  key_clinical_findings_output_tiers <- rbind(key_clinical_findings_output_tiers, key_clinical_findings_output_tier)
+  
+  # make changes to variant property column when TIER information is available
+  all_findings_output_tier <- all_findings_output %>% 
+    dplyr::filter(Aberration == gene_symbol & grepl(variant_classification, Details) & grepl(hgvs_short, Details)) %>%
+    dplyr::mutate(Variant_Properties =paste0(tier_class, "; ", Variant_Properties))
+  
+  all_findings_output_tiers <- rbind(all_findings_output_tiers, all_findings_output_tier)
 }
 
-# merge the modified rows back to the original table 
-key_clinical_findings_output_unchanged <- key_clinical_findings_output %>% 
-  dplyr::filter(!Details %in% key_clinical_findings_output_modified$Details)
+# filter to the ones that do not have modification
+key_clinical_findings_output_no_tier <- key_clinical_findings_output %>% 
+  dplyr::filter(!Details %in% key_clinical_findings_output_tiers$Details)
+# bind rows together
+key_clinical_findings_output <- bind_rows(key_clinical_findings_output_no_tier, key_clinical_findings_output_tiers)
 
-key_clinical_findings_output <- bind_rows(key_clinical_findings_output_modified, key_clinical_findings_output_unchanged)
+
+# filter to the ones that do not have modification
+all_findings_output_no_tier <- all_findings_output %>% 
+  dplyr::filter(!Details %in% all_findings_output_tiers$Details)
+# bind rows together
+all_findings_output <- bind_rows(all_findings_output_no_tier, all_findings_output_tiers)
+
 
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR added a R script that added `Tier: xx` and `Cancer Hotspot` to the tables in P1:
`key_clinical_findings_output` and `all_findings_output`.

https://github.com/d3b-center/bixu-tracker/issues/1214

## Type of review for this PR
- [ ] Scientific / output review
- [ ] Code quality review

note: scientific/output review requires the lead scientists or analysts of the project to be more focus on the output of the PR where code quality review requires reviewer to make sure the PR is following the [contributing guideline](https://www.notion.so/d3b/contributing-721d172616b24ff395a64c18c58534f5) 

Code review part:
- In this PR, I tried to write the path as what was normally used in OMPARE - please double check whether all the paths look good.
- For `key_clinical_findings_output` and `all_findings_output`, I just use them as is since I didn't see those results writing out anywhere and they were being called in the `OMPARE.Rmd`.
- This code takes in `oncokb_consensus_annotated.txt` and the output is annotated `key_clinical_findings_output` and `all_findings_output`
- Two more files `hotspot_database_2017_indel.tsv` and `hotspot_database_2017_snv.tsv` were needed (from [here](https://github.com/AlexsLemonade/OpenPBTA-analysis/tree/e760c463dc1d638385d53e1778c8e4d600b21fa2/analyses/hotspots-detection/input/hotspots_database) ) - in the code, I put them in `data/hotspots_database`
- This code needs to run after OncoKB analysis. 

Scientific review part:
- For the Tier IV, in the ticket it says ~50% and ~100% - I used between 40%-60% and >90% as criteria. Please check whether that is ok.
- Also for Tier IV, it was listed that it should  not contain COSMIC ID - but actually since COSMIC does contain some germline variant as well (a good amount of entries also has dbSNP ID) - I currently took it out from the criteria. We can add it back also but I would recommend using a criteria that `contains COSM and not dbSNP`.
- I see that PolyPhen and SIFT was added for Tier IV. I currently have them in the critter but just want to confirm this is intended.
- Please check how the SNV and indel hotspots are being assigned and see whether that looks good.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I tested with the `key_clinical_findings_output` downloaded from the patient 39 html. And for the `oncokb_consensus_annotated.txt`, I used a combined file with all `oncokb_consensus_annotated.txt` available in Cavatica (to make sure everything is captured correctly and wouldn't break).

- [ ] Unit test
- [ ] Integration test

**Test Configuration**:
* Environment:
* Test files:

**Task link/Screenshot/Terminal returns**:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have emojis in my PR and commits 😉
