### PR TITLE
Tier & Hotspot Mutation Annotation Update 

### DIFF
--- a/code/tier_classification/README.md
+++ b/code/tier_classification/README.md
@@ -13,7 +13,7 @@ Rscript tier_classification.R
 Input file `oncokb_consensus_annotated.txt`
 
 1. Tier 1 variants: 
-  a. Levels of evidence to include among Tier 1 would be: in the `HIGHEST_LEVEL` field, those with levels 1-3 or R1; OR in the `Highest DX Level`, levels 1-2; OR in the `Highest PX Level`, levels 1-2; OR annotated as `Tier 1` in COSMIC resistance variant database.
+  a. Levels of evidence to include among Tier 1 would be: in the `HIGHEST_LEVEL` field, those with levels 1-3 or R1; OR in the `Highest DX Level`, levels 1-2; OR in the `Highest PX Level`, levels 1-2; OR annotated as `Tier 1` in COSMIC resistance variant database; OR designated as `pathogenic` in `CLIN_SIG`.
   b. Mutation type: from MAF `Variant_Classification` field - missense, nonsense, indel (frameshift/non-frameshift), splice site, splice region.
   c. Variant allele frequency > 0.05: Calculated as `VAF = t_alt_count/(t_alt_count+t_ref_count)`
   d. Population database: from MAF - `gnomad_AF` < 0.01

--- a/code/tier_classification/README.md
+++ b/code/tier_classification/README.md
@@ -22,7 +22,7 @@ Input file `oncokb_consensus_annotated.txt`
   h. Publications: from `oncokb_consensus_annotated.txt`, `CITATIONS` is non-empty
 
 2. Tier 2 variants: 
-  a. Levels of evidence to include among Tier 2 would be: - in the `HIGHEST_LEVEL` field, those variants only with level 4 evidence OR R2; OR in the `Highest DX Level`, level 3; OR in the `Highest PX Level`, level 3; OR present in COSMIC resistance variant database without `Tier 1` annotated.
+  a. Levels of evidence to include among Tier 2 would be: - in the `HIGHEST_LEVEL` field, those variants only with level 4 evidence OR R2; OR in the `Highest DX Level`, level 3; OR in the `Highest PX Level`, level 3; OR present in COSMIC resistance variant database without `Tier 1` annotated; OR designated as `likely_pathogenic` in `CLIN_SIG`.
 (Note: a given variant may have multiple Levels of evidence in different indications, so long as the levels don't exceed 3 for DX or PX, nor 4 for `Level`, it would remain a Tier2 variant. If a variant has a level higher in any single one of these categories, it is a Tier 1 variant). 
   b. Mutation type: from MAF `Variant_Classification` field - missense, nonsense, indel (frameshift/non-frameshift), splice site, splice region.
   c. Variant allele frequency > 0.05: Calculated as `VAF = t_alt_count/(t_alt_count+t_ref_count)`

--- a/code/tier_classification/README.md
+++ b/code/tier_classification/README.md
@@ -13,20 +13,21 @@ Rscript tier_classification.R
 Input file `oncokb_consensus_annotated.txt`
 
 1. Tier 1 variants: 
-  a. Levels of evidence to include among Tier 1 would be: in the `HIGHEST_LEVEL` field, those with levels 1-3; OR in the `Highest DX Level`, levels 1-2; OR in the `Highest PX Level`, levels 1-2. 
+  a. Levels of evidence to include among Tier 1 would be: in the `HIGHEST_LEVEL` field, those with levels 1-3 or R1; OR in the `Highest DX Level`, levels 1-2; OR in the `Highest PX Level`, levels 1-2; OR annotated as `Tier 1` in COSMIC resistance variant database.
   b. Mutation type: from MAF `Variant_Classification` field - missense, nonsense, indel (frameshift/non-frameshift), splice site, splice region.
   c. Variant allele frequency > 0.05: Calculated as `VAF = t_alt_count/(t_alt_count+t_ref_count)`
   d. Population database: from MAF - `gnomad_AF` < 0.01
-  e. From MAF: `Existing_variation`: Must contain `COSM` identifier (found in COSMIC) or is present in COSMIC resistance hotspot table (downloaded from COSMIC)
+  e. From MAF: `Existing_variation`: Must contain `COSM` identifier (found in COSMIC) 
   g. Pathways: Known TSG or Oncogene given OMPARE knowledgebase (`cancer_gene_list.rds`). 
   h. Publications: from `oncokb_consensus_annotated.txt`, `CITATIONS` is non-empty
 
 2. Tier 2 variants: 
-  a. Levels of evidence to include among Tier 2 would be: - in the `HIGHEST_LEVEL` field, those variants only with level 4 evidence; OR in the `Highest DX Level`, level 3; OR in the `Highest PX Level`, level 3. (Note: a given variant may have multiple Levels of evidence in different indications, so long as the levels don't exceed 3 for DX or PX, nor 4 for `Level`, it would remain a Tier2 variant. If a variant has a level higher in any single one of these categories, it is a Tier 1 variant). 
+  a. Levels of evidence to include among Tier 2 would be: - in the `HIGHEST_LEVEL` field, those variants only with level 4 evidence OR R2; OR in the `Highest DX Level`, level 3; OR in the `Highest PX Level`, level 3; OR present in COSMIC resistance variant database without `Tier 1` annotated.
+(Note: a given variant may have multiple Levels of evidence in different indications, so long as the levels don't exceed 3 for DX or PX, nor 4 for `Level`, it would remain a Tier2 variant. If a variant has a level higher in any single one of these categories, it is a Tier 1 variant). 
   b. Mutation type: from MAF `Variant_Classification` field - missense, nonsense, indel (frameshift/non-frameshift), splice site, splice region.
   c. Variant allele frequency > 0.05: Calculated as `VAF = t_alt_count/(t_alt_count+t_ref_count)`
   d. Population database: from MAF - `gnomad_AF` < 0.01
-  e. From MAF: `Existing_variation`: Must contain `COSM` identifier (found in COSMIC) or is present in COSMIC resistance hotspot table (downloaded from COSMIC)
+  e. From MAF: `Existing_variation`: Must contain `COSM` identifier (found in COSMIC) 
   g. Pathways: Known TSG or Oncogene 
   h. Publications: from `oncokb_consensus_annotated.txt`, `CITATIONS` is non-empty
 

--- a/code/tier_classification/README.md
+++ b/code/tier_classification/README.md
@@ -17,7 +17,7 @@ Input file `oncokb_consensus_annotated.txt`
   b. Mutation type: from MAF `Variant_Classification` field - missense, nonsense, indel (frameshift/non-frameshift), splice site, splice region.
   c. Variant allele frequency > 0.05: Calculated as `VAF = t_alt_count/(t_alt_count+t_ref_count)`
   d. Population database: from MAF - `gnomad_AF` < 0.01
-  e. From MAF: `Existing_variation`: Must contain `COSM` identifier (found in COSMIC). 
+  e. From MAF: `Existing_variation`: Must contain `COSM` identifier (found in COSMIC) or is present in COSMIC resistance hotspot table (downloaded from COSMIC)
   g. Pathways: Known TSG or Oncogene given OMPARE knowledgebase (`cancer_gene_list.rds`). 
   h. Publications: from `oncokb_consensus_annotated.txt`, `CITATIONS` is non-empty
 
@@ -26,7 +26,7 @@ Input file `oncokb_consensus_annotated.txt`
   b. Mutation type: from MAF `Variant_Classification` field - missense, nonsense, indel (frameshift/non-frameshift), splice site, splice region.
   c. Variant allele frequency > 0.05: Calculated as `VAF = t_alt_count/(t_alt_count+t_ref_count)`
   d. Population database: from MAF - `gnomad_AF` < 0.01
-  e. From MAF: `Existing_variation`: Must contain `COSM` identifier (found in COSMIC). 
+  e. From MAF: `Existing_variation`: Must contain `COSM` identifier (found in COSMIC) or is present in COSMIC resistance hotspot table (downloaded from COSMIC)
   g. Pathways: Known TSG or Oncogene 
   h. Publications: from `oncokb_consensus_annotated.txt`, `CITATIONS` is non-empty
 
@@ -48,11 +48,13 @@ Input file `oncokb_consensus_annotated.txt`
   f. Pathways: Gene is not a known TSG or oncogene
   g. Publications: from `oncokb_consensus_annotated.txt`, `CITATIONS` is empty
   
-`hotspot_database_2017_indel.tsv` and `hotspot_database_2017_snv.tsv` derived from curated MSKCC data in OpenPBTA (https://github.com/AlexsLemonade/OpenPBTA-analysis/tree/master/analyses/hotspots-detection) were used for annotating cancer hotspot mutations.
+`hotspot_database_2017_indel.tsv` and `hotspot_database_2017_snv.tsv` derived from curated MSKCC data (downloaded from https://www.cancerhotspots.org/#/download), v2 version, using [this script](https://github.com/runjin326/CHOP_miscellaneous/blob/main/hotspot_prepare/hotspot_prep.R)
 
 To see whether SNV hotspot were present, the `key_clinical_findings_output` and `all_findings_output` were first filtered to contain only `Missense_Mutation`, `Nonsense_Mutation`, `Splic_Variant` and `Splice_Region`. 
-For every entry in the hotspot file, the gene symbol and AA position were used to query the `key_clinical_findings_output` and `all_findings_output` table to see whether they are present - if yes, then `Cancer Hotspot` annotation will be added to the `Variant_Properties` column.
+For every entry in the hotspot file, the gene symbol and AA position were used to query the `key_clinical_findings_output` and `all_findings_output` table to see whether they are present.
+If the exact variant is present, then `Cancer Hotspot` annotation will be added to the `Variant_Properties` column;
+If the exact variant is not present but the AA position matches with hotspot AA position, then then `Cancer Hotspot Location` annotation will be added to the `Variant_Properties` column.
 
 To see whether indel hotspot were present, the `key_clinical_findings_output` and `all_findings_output` were first filtered to contain only `Frame_Shift_Del`, `Frame_Shift_Ins`m `In_Frame_Del` and `In_Frame_Ins`. 
-For every entry in the indel hotspot file, the gene symbol and AA start and end position were used to query the `key_clinical_findings_output` and `all_findings_output` table to see whether they are present - if yes, then `Cancer Hotspot` annotation will be added to the `Variant_Properties` column.
+For every entry in the indel hotspot file, the gene symbol and `HGVSp_Short` were used to query the `key_clinical_findings_output` and `all_findings_output` table to see whether they are present - if yes, then `Cancer Hotspot` annotation will be added to the `Variant_Properties` column.
 

--- a/code/tier_classification/tier_classification.R
+++ b/code/tier_classification/tier_classification.R
@@ -228,10 +228,12 @@ if(nrow(oncokb_anno) == 0){
     key_clinical_findings_output_indels <- data.frame()
     
     all_findings_output_mnv <- all_findings_output %>%
-      dplyr::filter(grepl("Frame_Shift_Del", Details) | grepl("Frame_Shift_Ins", Details) | grepl("In_Frame_Del", Details) | grepl("In_Frame_Ins", Details))
+      dplyr::filter(grepl("Frame_Shift_Del", Details) | grepl("Frame_Shift_Ins", Details) | grepl("In_Frame_Del", Details) | grepl("In_Frame_Ins", Details)) %>%
+      dplyr::mutate(specific = gsub(".*HGVSp: ", "", Details)) 
       
     key_findings_output_mnv <- key_findings_output %>%
-      dplyr::filter(grepl("Frame_Shift_Del", Details) | grepl("Frame_Shift_Ins", Details) | grepl("In_Frame_Del", Details) | grepl("In_Frame_Ins", Details))
+      dplyr::filter(grepl("Frame_Shift_Del", Details) | grepl("Frame_Shift_Ins", Details) | grepl("In_Frame_Del", Details) | grepl("In_Frame_Ins", Details)) %>%
+      dplyr::mutate(specific = gsub(".*HGVSp: ", "", Details)) 
       
     for(q in 1:nrow(hotspot_indel)){
       
@@ -241,14 +243,16 @@ if(nrow(oncokb_anno) == 0){
       
       all_findings_output_indel <- all_findings_output_mnv %>%
         dplyr::filter(Aberration == hotspot_gene_indel) %>%
-        dplyr::filter(grepl(hotspot_specific_indel, Details)) %>%
-        dplyr::mutate(Variant_Properties= paste0("Cancer Hotspot; ", Variant_Properties))
+        dplyr::filter(specific == hotspot_specific_indel) %>%
+        dplyr::mutate(Variant_Properties= paste0("Cancer Hotspot; ", Variant_Properties)) %>%
+        dplyr::select(-specific)
       all_findings_output_indels <- bind_rows(all_findings_output_indel, all_findings_output_indels)
       
       key_clinical_findings_output_indel <- key_findings_output_mnv %>%
         dplyr::filter(Aberration == hotspot_gene_indel) %>%
-        dplyr::filter(grepl(hotspot_specific_indel, Details)) %>%
-        dplyr::mutate(Variant_Properties= paste0("Cancer Hotspot; ", Variant_Properties))
+        dplyr::filter(specific == hotspot_specific_indel) %>%
+        dplyr::mutate(Variant_Properties= paste0("Cancer Hotspot; ", Variant_Properties)) %>%
+        dplyr::select(-specific)
       key_clinical_findings_output_indels <- bind_rows(key_clinical_findings_output_indel, key_clinical_findings_output_indels)
     }
     

--- a/code/tier_classification/tier_classification.R
+++ b/code/tier_classification/tier_classification.R
@@ -71,7 +71,7 @@ if(nrow(oncokb_anno) == 0){
                                                 'In_Frame_Del', 'In_Frame_Ins', 
                                                 'Splice_Region', 'Splice_Site')) %>%
     # filter based on OncoKB annotation level 
-    dplyr::filter(HIGHEST_LEVEL %in% c("LEVEL_1","LEVEL_2","LEVEL_3A", "LEVEL_3B", "LEVEL_R1") | HIGHEST_DX_LEVEL %in% c("LEVEL_Dx1","LEVEL_Dx2") | HIGHEST_PX_LEVEL %in% c("LEVEL_Px1","LEVEL_Px2" | cosmic_tier_anno == "Yes")) %>%
+    dplyr::filter(HIGHEST_LEVEL %in% c("LEVEL_1","LEVEL_2","LEVEL_3A", "LEVEL_3B", "LEVEL_R1") | HIGHEST_DX_LEVEL %in% c("LEVEL_Dx1","LEVEL_Dx2") | HIGHEST_PX_LEVEL %in% c("LEVEL_Px1","LEVEL_Px2") | cosmic_tier_anno == "Yes" | grepl('\bpathogenic\b', CLIN_SIG)) %>%
     # contain only variants that are <1% (less likely to be germline)
     dplyr::filter(gnomAD_AF<0.01| is.na(gnomAD_AF)) %>%
     # filter on VAF over 5% to avoid background noise

--- a/code/tier_classification/tier_classification.R
+++ b/code/tier_classification/tier_classification.R
@@ -93,7 +93,7 @@ if(nrow(oncokb_anno) == 0){
                                                 'In_Frame_Del', 'In_Frame_Ins', 
                                                 'Splice_Region', 'Splice_Site')) %>%
     # filter based on OncoKB annotation level 
-    dplyr::filter(HIGHEST_LEVEL %in% c("LEVEL_4","LEVEL_R2") | HIGHEST_DX_LEVEL %in% c("LEVEL_Dx3") | HIGHEST_PX_LEVEL %in% c("LEVEL_Px3") | cosmic_tier_anno == "No" | grepl('likely_pathogenic', CLIN_SIG)) %>%
+    dplyr::filter(HIGHEST_LEVEL %in% c("LEVEL_4","LEVEL_R2") | HIGHEST_DX_LEVEL %in% c("LEVEL_Dx3") | HIGHEST_PX_LEVEL %in% c("LEVEL_Px3") | cosmic_tier_anno == "No" | (grepl('likely_pathogenic', CLIN_SIG) & !grepl('\\bpathogenic\\b', CLIN_SIG))) %>%
     # contain only variants that are <1% (less likely to be germline)
     dplyr::filter(gnomAD_AF<0.01| is.na(gnomAD_AF)) %>%
     # filter on VAF over 5% to avoid background noise

--- a/code/tier_classification/tier_classification.R
+++ b/code/tier_classification/tier_classification.R
@@ -93,7 +93,7 @@ if(nrow(oncokb_anno) == 0){
                                                 'In_Frame_Del', 'In_Frame_Ins', 
                                                 'Splice_Region', 'Splice_Site')) %>%
     # filter based on OncoKB annotation level 
-    dplyr::filter(HIGHEST_LEVEL %in% c("LEVEL_4","LEVEL_R2") | HIGHEST_DX_LEVEL %in% c("LEVEL_Dx3") | HIGHEST_PX_LEVEL %in% c("LEVEL_Px3") | cosmic_tier_anno == "No") %>%
+    dplyr::filter(HIGHEST_LEVEL %in% c("LEVEL_4","LEVEL_R2") | HIGHEST_DX_LEVEL %in% c("LEVEL_Dx3") | HIGHEST_PX_LEVEL %in% c("LEVEL_Px3") | cosmic_tier_anno == "No" | grepl('likely_pathogenic', CLIN_SIG)) %>%
     # contain only variants that are <1% (less likely to be germline)
     dplyr::filter(gnomAD_AF<0.01| is.na(gnomAD_AF)) %>%
     # filter on VAF over 5% to avoid background noise

--- a/code/tier_classification/tier_classification.R
+++ b/code/tier_classification/tier_classification.R
@@ -197,19 +197,19 @@ if(nrow(oncokb_anno) == 0){
       all_findings_output_hotspots <- bind_rows(all_findings_output_hotspots, all_findings_output_hotspot)
       
       # now deal with key clinical findings
-      key_findings_output_hotspot <- key_findings_output_snv %>%
+      key_clinical_findings_output_hotspot <- key_findings_output_snv %>%
         dplyr::filter(Aberration == hotspot_gene,
                       position == hotspot_aa_position) %>%
         dplyr::select(-position)
 
-      if(nrow(key_findings_output_hotspot)>0){
-        key_findings_output_hotspot <- key_findings_output_hotspot %>%
+      if(nrow(key_clinical_findings_output_hotspot)>0){
+        key_clinical_findings_output_hotspot <- key_clinical_findings_output_hotspot %>%
           dplyr::mutate(Variant_Properties= case_when(
             grepl(hotspot_aa, Details) ~ paste0("Cancer Hotspot; ", Variant_Properties),
             TRUE ~ paste0("Cancer Hotspot Location; ", Variant_Properties)
           ))
       }
-      key_findings_output_hotspots <- bind_rows(key_findings_output_hotspots, key_findings_output_hotspot)
+      key_clinical_findings_output_hotspots <- bind_rows(key_clinical_findings_output_hotspots, key_clinical_findings_output_hotspot)
     }
     
     # add the annotations to the file 

--- a/code/tier_classification/tier_classification.R
+++ b/code/tier_classification/tier_classification.R
@@ -71,7 +71,7 @@ if(nrow(oncokb_anno) == 0){
                                                 'In_Frame_Del', 'In_Frame_Ins', 
                                                 'Splice_Region', 'Splice_Site')) %>%
     # filter based on OncoKB annotation level 
-    dplyr::filter(HIGHEST_LEVEL %in% c("LEVEL_1","LEVEL_2","LEVEL_3A", "LEVEL_3B", "LEVEL_R1") | HIGHEST_DX_LEVEL %in% c("LEVEL_Dx1","LEVEL_Dx2") | HIGHEST_PX_LEVEL %in% c("LEVEL_Px1","LEVEL_Px2") | cosmic_tier_anno == "Yes" | grepl('\bpathogenic\b', CLIN_SIG)) %>%
+    dplyr::filter(HIGHEST_LEVEL %in% c("LEVEL_1","LEVEL_2","LEVEL_3A", "LEVEL_3B", "LEVEL_R1") | HIGHEST_DX_LEVEL %in% c("LEVEL_Dx1","LEVEL_Dx2") | HIGHEST_PX_LEVEL %in% c("LEVEL_Px1","LEVEL_Px2") | cosmic_tier_anno == "Yes" | grepl('\\bpathogenic\\b', CLIN_SIG)) %>%
     # contain only variants that are <1% (less likely to be germline)
     dplyr::filter(gnomAD_AF<0.01| is.na(gnomAD_AF)) %>%
     # filter on VAF over 5% to avoid background noise

--- a/code/tier_classification/tier_classification.R
+++ b/code/tier_classification/tier_classification.R
@@ -31,6 +31,16 @@ if(nrow(oncokb_anno) == 0){
   hotspot_snv <- readr::read_tsv(file.path(data_dir, 'hotspots_database', 'hotspot_database_2017_snv.tsv')) %>%
     distinct()
   
+  # read in COSMIC resistance marker df
+  cosmic_resistance <- readr::read_tsv(file.path(data_dir, 'CosmicResistanceMutations.tsv')) %>% 
+    dplyr::select(`Gene Name`, `AA Mutation`, `CDS Mutation`) %>% 
+    dplyr::mutate(cosmic_resistance_variant = "Yes", 
+                  `Gene Name` = gsub("\\_.*", "", `Gene Name`)) %>% 
+    dplyr::rename(HGVSp_Short = `AA Mutation`, 
+                  HGVSc = `CDS Mutation`, 
+                  Hugo_Symbol = `Gene Name`) %>%
+    distinct()
+  
   # subset to genes in all_findings_output corresponding to VUS and Mutation
   genes_of_interest <- all_findings_output %>%
     filter(Type %in% c("VUS", "Mutation")) %>% 
@@ -38,7 +48,7 @@ if(nrow(oncokb_anno) == 0){
   hotspot_snv <- hotspot_snv %>% 
     filter(Hugo_Symbol %in% genes_of_interest)
   hotspot_indel <- hotspot_indel %>%
-    filter(Hugo_Symbol %in% hotspot_snv)
+    filter(Hugo_Symbol %in% hotspot_snv$Hugo_Symbol)
   
   # find the oncogenes tumor suppressor genes in OMPARE knowledge base
   oncogenes_tsg <- cancer_genes %>%
@@ -47,7 +57,8 @@ if(nrow(oncokb_anno) == 0){
   
   # calculate VAF for subsequent classification 
   oncokb_anno <- oncokb_anno %>% 
-    dplyr::mutate(VAF = t_alt_count/(t_alt_count+t_ref_count))
+    dplyr::mutate(VAF = t_alt_count/(t_alt_count+t_ref_count)) %>% 
+    left_join(cosmic_resistance)
   
   # Filter for Tier I
   oncokb_anno_tier1 <- oncokb_anno %>% 
@@ -62,18 +73,12 @@ if(nrow(oncokb_anno) == 0){
     dplyr::filter(gnomAD_AF<0.01| is.na(gnomAD_AF)) %>%
     # filter on VAF over 5% to avoid background noise
     dplyr::filter(VAF>0.05) %>%
-    # filter to contain only mutations that has COSMIC ID
-    dplyr::mutate(has_COSMIC = dplyr::case_when(
-      stringr::str_detect(Existing_variation,
-                          "COSM") ~ "Yes",
-      TRUE ~ "No"
-    )) %>%
-    dplyr::filter(has_COSMIC == "Yes") %>%
+    # filter to contain only mutations that has COSMIC ID or has resistance mutation
+    dplyr::filter(grepl("COSM", Existing_variation) | cosmic_resistance_variant == "Yes") %>% 
     # filter to contain only mutations with citations
     dplyr::filter(!is.na(CITATIONS)) %>% 
     # filter to TSG lists in OMPARE database
     dplyr::filter(Hugo_Symbol %in% oncogenes_tsg ) %>% 
-    dplyr::select(-has_COSMIC) %>% 
     dplyr::mutate(tier_classification = "TIER: I")
   
   
@@ -90,18 +95,12 @@ if(nrow(oncokb_anno) == 0){
     dplyr::filter(gnomAD_AF<0.01| is.na(gnomAD_AF)) %>%
     # filter on VAF over 5% to avoid background noise
     dplyr::filter(VAF>0.05) %>%
-    # filter to contain only mutations that has COSMIC ID
-    dplyr::mutate(has_COSMIC = dplyr::case_when(
-      stringr::str_detect(Existing_variation,
-                          "COSM") ~ "Yes",
-      TRUE ~ "No"
-    )) %>%
-    dplyr::filter(has_COSMIC == "Yes") %>%
+    # filter to contain only mutations that has COSMIC ID or has resistance mutation
+    dplyr::filter(grepl("COSM", Existing_variation) | cosmic_resistance_variant == "Yes") %>% 
     # filter to contain only mutations with citations
     dplyr::filter(!is.na(CITATIONS)) %>% 
     # filter to TSG lists in OMPARE database
     dplyr::filter(Hugo_Symbol %in% oncogenes_tsg ) %>% 
-    dplyr::select(-has_COSMIC) %>% 
     dplyr::mutate(tier_classification = "TIER: II")
   
   
@@ -145,29 +144,69 @@ if(nrow(oncokb_anno) == 0){
   ######################### annotate MSK SNV hotspot database to key clinical findings & all findings table
   
   # annotate SNV first
-  if(nrow(hotspot_snv)){
+  if(nrow(hotspot_snv)>0){
+    # modify the clinical output files for easier manipulation
+    all_findings_output_snv <- all_findings_output %>% 
+      dplyr::filter(grepl("Missense_Mutation", Details) | grepl("Nonsense_Mutation", Details) | grepl("Splice_Site", Details) | grepl("Splice_Region", Details)) %>%
+      dplyr::mutate(position = gsub(".*HGVSp: p..", "", Details)) %>% 
+      dplyr::mutate(position =str_sub(position, end = -2))
+    
+    key_findings_output_snv <- key_findings_output %>% 
+      dplyr::filter(grepl("Missense_Mutation", Details) | grepl("Nonsense_Mutation", Details) | grepl("Splice_Site", Details) | grepl("Splice_Region", Details)) %>%
+      dplyr::mutate(position = gsub(".*HGVSp: p..", "", Details)) %>% 
+      dplyr::mutate(position =str_sub(position, end = -2))
+      
     all_findings_output_hotspots <- data.frame()
     key_clinical_findings_output_hotspots <- data.frame()
     
-    for(p in 1:nrow(hotspot_snv)){
+    snv_location <- hotspot_snv %>% 
+      dplyr::select(Hugo_Symbol, Amino_Acid_Position) %>% 
+      distinct()
+    
+    for(p in 1:nrow(snv_location)){
       
-      each_entry <- hotspot_snv[p,]
+      each_entry <- snv_location[p,]
       hotspot_gene <- each_entry$Hugo_Symbol
       hotspot_aa_position <- each_entry$Amino_Acid_Position
       
-      all_findings_output_hotspot <- all_findings_output %>%
-        dplyr::filter(Aberration == hotspot_gene & grepl(hotspot_aa_position, Details)) %>%
-        dplyr::filter(grepl("Missense_Mutation", Details) | grepl("Nonsense_Mutation", Details) | grepl("Splice_Site", Details) | grepl("Splice_Region", Details))%>%
-        dplyr::mutate(Variant_Properties= paste0("Cancer Hotspot Location; ", Variant_Properties))
+      # find all the specific AA mutations in the hotspot table
+      hotspot_aa <- hotspot_snv %>% 
+        dplyr::filter(Amino_Acid_Position == hotspot_aa_position,
+                      Hugo_Symbol==hotspot_gene) %>%
+        dplyr::pull(HGVSp_short)
       
+      # reformat to make it matchable 
+      hotspot_aa<-paste(noquote(hotspot_aa),collapse='|')
+      
+      # first deal with all clinical findings table
+      all_findings_output_hotspot <- all_findings_output_snv %>%
+        dplyr::filter(Aberration == hotspot_gene,
+                      position == hotspot_aa_position) %>%
+        dplyr::select(-position)
+      
+      if(nrow(all_findings_output_hotspot)>0){
+        all_findings_output_hotspot <- all_findings_output_hotspot %>%
+          dplyr::mutate(Variant_Properties= case_when(
+            grepl(hotspot_aa, Details) ~ paste0("Cancer Hotspot; ", Variant_Properties),
+            TRUE ~ paste0("Cancer Hotspot Location; ", Variant_Properties)
+          ))
+        }
       all_findings_output_hotspots <- bind_rows(all_findings_output_hotspots, all_findings_output_hotspot)
       
-      key_clinical_findings_output_hotspot <- key_clinical_findings_output %>% 
-        dplyr::filter(Aberration == hotspot_gene & grepl(hotspot_aa_position, Details)) %>%
-        dplyr::filter(grepl("Missense_Mutation", Details) | grepl("Nonsense_Mutation", Details) | grepl("Splice_Site", Details) | grepl("Splice_Region", Details))%>%
-        dplyr::mutate(Variant_Properties= paste0("Cancer Hotspot Location; ", Variant_Properties))
-      
-      key_clinical_findings_output_hotspots <- bind_rows(key_clinical_findings_output_hotspots, key_clinical_findings_output_hotspot)
+      # now deal with key clinical findings
+      key_findings_output_hotspot <- key_findings_output_snv %>%
+        dplyr::filter(Aberration == hotspot_gene,
+                      position == hotspot_aa_position) %>%
+        dplyr::select(-position)
+
+      if(nrow(key_findings_output_hotspot)>0){
+        key_findings_output_hotspot <- key_findings_output_hotspot %>%
+          dplyr::mutate(Variant_Properties= case_when(
+            grepl(hotspot_aa, Details) ~ paste0("Cancer Hotspot; ", Variant_Properties),
+            TRUE ~ paste0("Cancer Hotspot Location; ", Variant_Properties)
+          ))
+      }
+      key_findings_output_hotspots <- bind_rows(key_findings_output_hotspots, key_findings_output_hotspot)
     }
     
     # add the annotations to the file 
@@ -184,27 +223,32 @@ if(nrow(oncokb_anno) == 0){
   ######################### annotate MSK Indel hotspot database to key clinical findings & all findings table
   
   # annotate Indel now
-  if(nrow(hotspot_indel)){
+  if(nrow(hotspot_indel)>0){
     all_findings_output_indels <- data.frame()
     key_clinical_findings_output_indels <- data.frame()
     
+    all_findings_output_mnv <- all_findings_output %>%
+      dplyr::filter(grepl("Frame_Shift_Del", Details) | grepl("Frame_Shift_Ins", Details) | grepl("In_Frame_Del", Details) | grepl("In_Frame_Ins", Details))
+      
+    key_findings_output_mnv <- key_findings_output %>%
+      dplyr::filter(grepl("Frame_Shift_Del", Details) | grepl("Frame_Shift_Ins", Details) | grepl("In_Frame_Del", Details) | grepl("In_Frame_Ins", Details))
+      
     for(q in 1:nrow(hotspot_indel)){
       
       each_indel <- hotspot_indel[q,]
       hotspot_gene_indel <- each_indel$Hugo_Symbol
-      hotspot_aa_start <- each_indel$Amino_Acid_Start
-      hotspot_aa_end <- each_indel$Amino_Acid_End
+      hotspot_specific_indel <- each_indel$HGVSp_short
       
-      all_findings_output_indel <- all_findings_output %>%
-        dplyr::filter(Aberration == hotspot_gene_indel & grepl(hotspot_aa_start, Details) & grepl(hotspot_aa_end, Details)) %>%
-        dplyr::filter(grepl("Frame_Shift_Del", Details) | grepl("Frame_Shift_Ins", Details) | grepl("In_Frame_Del", Details) | grepl("In_Frame_Ins", Details))%>%
-        mutate(Variant_Properties= paste0("Cancer Hotspot; ", Variant_Properties))
+      all_findings_output_indel <- all_findings_output_mnv %>%
+        dplyr::filter(Aberration == hotspot_gene_indel) %>%
+        dplyr::filter(grepl(hotspot_specific_indel, Details)) %>%
+        dplyr::mutate(Variant_Properties= paste0("Cancer Hotspot; ", Variant_Properties))
       all_findings_output_indels <- bind_rows(all_findings_output_indel, all_findings_output_indels)
       
-      key_clinical_findings_output_indel <- key_clinical_findings_output %>%
-        dplyr::filter(Aberration == hotspot_gene_indel & grepl(hotspot_aa_start, Details) & grepl(hotspot_aa_end, Details)) %>%
-        dplyr::filter(grepl("Frame_Shift_Del", Details) | grepl("Frame_Shift_Ins", Details) | grepl("In_Frame_Del", Details) | grepl("In_Frame_Ins", Details))%>%
-        mutate(Variant_Properties= paste0("Cancer Hotspot; ", Variant_Properties))
+      key_clinical_findings_output_indel <- key_findings_output_mnv %>%
+        dplyr::filter(Aberration == hotspot_gene_indel) %>%
+        dplyr::filter(grepl(hotspot_specific_indel, Details)) %>%
+        dplyr::mutate(Variant_Properties= paste0("Cancer Hotspot; ", Variant_Properties))
       key_clinical_findings_output_indels <- bind_rows(key_clinical_findings_output_indel, key_clinical_findings_output_indels)
     }
     


### PR DESCRIPTION
## Description
This PR fixes issue 1259 with the following approaches:
1) For OpenPBTA and OT, currently, the hotspot rescue is applied by location matching, not variant matching - hence, `https://github.com/PediatricOpenTargets/OpenPedCan-analysis/blob/dev/analyses/hotspots-detection/results/pbta-snv-scavenged-hotspots.maf.tsv.gz` this file might contain variants that are in hotspot location but not actually a hotspot variant. Additionally, OT does not have this intermediate file - it is in a compiled workflow now. 
    - Hence, I download the original file from `https://www.cancerhotspots.org/#/download` directly 
    - I used the [code here](https://github.com/runjin326/CHOP_miscellaneous/blob/main/hotspot_prepare/hotspot_prep.R) to generate 2 new files as data input - can [download here](https://github.com/runjin326/CHOP_miscellaneous/tree/main/hotspot_prepare/output)
        - `hotspot_database_2017_indel.tsv` 
        -  `hotspot_database_2017_snv.tsv` 

2. Another input file, resistance mutation for COSMIC [can be found here](https://github.com/runjin326/CHOP_miscellaneous/blob/main/maf_tier_classification/references/CosmicResistanceMutations.tsv) - this is downloaded directly from COSMIC website.

3. For matching SNV, if the variant matches hotspot variant, it is annotated as `Cancer Hotspot` and if only the location matches, it is annotated as `Cancer Hotspot Location`
    - Also realized that the previous way of using `grepl` to see whether the location matches is not accurate - this would lead to false positive: e.g., hotspot location is 61, then using `grepl`, location 6 would be annotated as hotspot location as well... hence, modified to take exact match. 

4.  For matching indel, if the variant matches hotspot variant, it is annotated as `Cancer Hotspot` - currently, there is no annotation of `Cancer Hotspot Location` - do we want to leave it as is, or add this criteria. If so, should we match both start and end position? Or just the start position? Or any position between the start and end? 

Fixes # (issue)
https://github.com/d3b-center/bixu-tracker/issues/1259

## Type of review for this PR
- [x] Scientific / output review
- [x] Code quality review

note: scientific/output review requires the lead scientists or analysts of the project to be more focus on the output of the PR where code quality review requires reviewer to make sure the PR is following the [contributing guideline](https://www.notion.so/d3b/contributing-721d172616b24ff395a64c18c58534f5) 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I downloaded key findings and all findings output from patient 33 and ran the code with those two files - the results and annotation are as expected.

- [ ] Unit test
- [ ] Integration test

**Test Configuration**:
* Environment:
* Test files:

**Task link/Screenshot/Terminal returns**:

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [ ] I have emojis in my PR and commits 😉
